### PR TITLE
feat: add chat UI for agentic coding pipeline

### DIFF
--- a/Agentic-Coding-Pipeline/README.md
+++ b/Agentic-Coding-Pipeline/README.md
@@ -22,12 +22,13 @@ It orchestrates **specialized LLM agents**, **local developer tooling**, and **g
 
 ## Contents
 
+* [Overview](#overview)
 * [What you get](#what-you-get)
 * [Architecture](#architecture)
 * [Prerequisites](#prerequisites)
 * [Install](#install)
 * [Configure](#configure)
-* [Run](#run)
+* [Running the Pipeline](#running-the-pipeline)
 * [Control room UI](#control-room-ui)
 * [How it works (step-by-step)](#how-it-works-step-by-step)
 * [State contract](#state-contract)
@@ -37,12 +38,22 @@ It orchestrates **specialized LLM agents**, **local developer tooling**, and **g
 * [Test orchestration](#test-orchestration)
 * [Formatting & patch hygiene](#formatting--patch-hygiene)
 * [Tooling & integration patterns](#tooling--integration-patterns)
-* [MCP integration](#mcp-integration)
-* [Extending & customization](#extending--customization)
+* [MCP Server Integration](#mcp-server-integration)
+* [Extending](#extending)
 * [Operations & observability](#operations--observability)
 * [Quality control & failure handling](#quality-control--failure-handling)
+* [Tests](#tests)
 * [Troubleshooting](#troubleshooting)
 * [FAQ](#faq)
+
+---
+
+## Overview
+
+This pipeline combines multiple specialized agents with developer tooling to ship reliable patches autonomously. Coding agents
+draft and refine changes, a formatter normalizes style, a testing agent authorizes pytest suites, and a QA reviewer enforces a
+final human-like gate. The orchestrator loops through these stages until every check passes or retries are exhausted, mirroring
+the design documented in the Agentic RAG Pipeline guide so both experiences share a consistent operational feel.
 
 ---
 
@@ -211,7 +222,7 @@ Each agent reads from these keys when instantiated, so they must be available be
 
 ---
 
-## Run
+## Running the Pipeline
 
 ### CLI (batteries included)
 
@@ -413,7 +424,7 @@ Swap or augment these strings in custom agents to target different languages, fr
 
 ---
 
-## MCP integration
+## MCP Server Integration
 
 This pipeline registers with the shared [`mcp`](../mcp) package. The FastAPI-backed **MCPServer** exposes a unified toolbox (web search, browsing, direct LLM calls) so any pipeline in the monorepo can dispatch coding tasks remotely or as part of a larger workflow.
 
@@ -426,7 +437,7 @@ To plug this pipeline into the MCP network:
 
 ---
 
-## Extending & customization
+## Extending
 
 * **Swap models** – Pass alternative `LLMClient` implementations when constructing agents (e.g., Azure OpenAI, local models).
 * **Add new stages** – Extend the `formatters`, `testers`, or `reviewers` lists with additional agents (docs generation, security scans, benchmarks).
@@ -452,6 +463,19 @@ To plug this pipeline into the MCP network:
 * Test and QA failures attach their raw outputs to `feedback`, giving subsequent iterations or humans concrete guidance.
 * Exhausting the iteration budget marks the run as `failed`, preserving the last known state for inspection.
 * Unit tests validate that the orchestrator reaches a completed state with deterministic mock responses, preventing regressions in the loop contract.
+
+---
+
+## Tests
+
+Run the bundled checks to verify the pipeline end-to-end:
+
+```bash
+ruff check Agentic-Coding-Pipeline
+pytest Agentic-Coding-Pipeline/tests/test_pipeline.py
+```
+
+Pair these with the control room UI or CLI examples above when validating changes locally.
 
 ---
 

--- a/Agentic-Coding-Pipeline/README.md
+++ b/Agentic-Coding-Pipeline/README.md
@@ -1,41 +1,485 @@
-# Agentic Coding Pipeline
+# Agentic Coding Pipeline (with Multi-LLM Pair Programming)
 
-An autonomous, multi-agent workflow that iteratively edits a codebase until LLM-generated tests and reviews pass.
+An end-to-end, production-ready **agentic coding** loop that continuously drafts, formats, tests, and reviews code until quality gates pass.
+It orchestrates **specialized LLM agents**, **local developer tooling**, and **git-friendly utilities** so you can ship reliable patches on autopilot.
 
-## Overview
+[![Python](https://img.shields.io/badge/Python-3.10%2B-3776AB?logo=python&logoColor=white)](#)
+[![Poetry](https://img.shields.io/badge/Poetry-Environment%20Mgmt-60A5FA?logo=poetry&logoColor=white)](#)
+[![OpenAI](https://img.shields.io/badge/OpenAI-GPT%20Coders-412991?logo=openai&logoColor=white)](#)
+[![Anthropic](https://img.shields.io/badge/Anthropic-Claude%20Coders-18181B?logo=apache&logoColor=white)](#)
+[![Google Gemini](https://img.shields.io/badge/Google%20Gemini-QA%20Review-4285F4?logo=google&logoColor=white)](#)
+[![Pytest](https://img.shields.io/badge/Pytest-Test%20Runner-0A9EDC?logo=pytest&logoColor=white)](#)
+[![Ruff](https://img.shields.io/badge/Ruff-Autoformat-000000?logo=ruff&logoColor=white)](#)
+[![Git](https://img.shields.io/badge/Git-Patch%20Workflows-F05032?logo=git&logoColor=white)](#)
+[![CLI](https://img.shields.io/badge/CLI-Argparse-4EAA25?logo=gnu-bash&logoColor=white)](#)
+[![Makefile](https://img.shields.io/badge/Makefile-Developer%20Tasks-000000?logo=gnu&logoColor=white)](#)
+[![Automation](https://img.shields.io/badge/Automation-Iterative%20Loop-FF9800?logo=robot&logoColor=white)](#)
+[![Code%20Quality](https://img.shields.io/badge/Code%20Quality-Tests%20%2B%20QA-4C1?logo=codequality&logoColor=white)](#)
+[![MCP](https://img.shields.io/badge/MCP-Shared%20Agent%20Bus-6B4BA1?logo=protocol&logoColor=white)](#)
+[![Open%20Source](https://img.shields.io/badge/Open%20Source-Contributions%20Welcome-FF5722?logo=open-source-initiative&logoColor=white)](#)
 
-This pipeline coordinates several specialized agents backed by pluggable LLM providers:
+---
 
-- **Coding agents** synthesize or refine patches. By default both OpenAI and Claude models collaborate to produce code.
-- **Formatting agents** run local tooling (e.g. `ruff --fix`) to keep style consistent.
-- **Testing agents** ask an LLM (default Claude) to draft pytest suites and execute them locally.
-- **QA/QC agents** perform LLM-based code review (default Gemini) to ensure style and correctness.
-- **Orchestrator** loops until all checks succeed or a retry limit is reached.
+## Contents
 
-The design is modular so additional roles (documentation, security, deployment, etc.) can be plugged in without altering the core loop.
+* [What you get](#what-you-get)
+* [Architecture](#architecture)
+* [Prerequisites](#prerequisites)
+* [Install](#install)
+* [Configure](#configure)
+* [Run](#run)
+* [Control room UI](#control-room-ui)
+* [How it works (step-by-step)](#how-it-works-step-by-step)
+* [State contract](#state-contract)
+* [Project structure](#project-structure)
+* [Agents (roles & prompts)](#agents-roles--prompts)
+* [Prompt reference](#prompt-reference)
+* [Test orchestration](#test-orchestration)
+* [Formatting & patch hygiene](#formatting--patch-hygiene)
+* [Tooling & integration patterns](#tooling--integration-patterns)
+* [MCP integration](#mcp-integration)
+* [Extending & customization](#extending--customization)
+* [Operations & observability](#operations--observability)
+* [Quality control & failure handling](#quality-control--failure-handling)
+* [Troubleshooting](#troubleshooting)
+* [FAQ](#faq)
 
-## MCP Server Integration
+---
 
-The pipeline registers with the shared [`mcp`](../mcp) package. A central `MCPServer` allows any of the project pipelines (research outreach, RAG, or coding) to dispatch tasks through a common FastAPI server that also exposes web search, browsing tools and direct LLM access.
+## What you get
 
-## Running the Pipeline
+* **Multi-LLM pair programming** – GPT and Claude coders collaborate, sharing structured state between passes for richer iterations.
+* **Autonomous refinement loop** – The orchestrator keeps iterating until formatting, tests, and QA all succeed or retries are exhausted.
+* **Tool-backed quality gates** – Ruff auto-fixes style, pytest executes LLM-authored suites, and Gemini reviews the diff before completion.
+* **Git-friendly helpers** to commit generated patches directly from agents when desired.
+* **Drop-in modularity** – Swap models or add agents without rewriting the orchestration contract thanks to a shared `Agent` protocol.
+* **Regression safety net** – Lightweight unit tests validate orchestration behaviour, providing confidence when extending the loop.
 
-```bash
-cd Agentic-Coding-Pipeline
-python run.py "Add feature X"
+---
+
+## Architecture
+
+The flowchart below maps the agents that participate in a single iteration and how state moves between them.
+
+```mermaid
+flowchart TD
+    U[Developer Task] --> OR[AgenticCodingPipeline\n(Iterative Orchestrator)]
+    OR -->|state| GPT[GPT Coding Agent]
+    OR -->|state| CLAUDE[Claude Coding Agent]
+    GPT --> OR
+    CLAUDE --> OR
+    OR --> F[Ruff Formatter]
+    F --> OR
+    OR --> T[Claude Test Author\nPytest Runner]
+    T -->|tests pass?| OR
+    OR --> Q[Gemini QA Reviewer]
+    Q -->|PASS?| OR
+    OR -->|status| OUT[Ready-to-commit Patch]
+    OR -. feedback .-> GPT
+    OR -. feedback .-> CLAUDE
 ```
 
-The default configuration uses OpenAI and Claude for coding, formats code with Ruff, generates tests with Claude and reviews with Gemini. Set the corresponding API keys (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`) so agents can call each provider. Local tooling such as `pytest` is used to run the tests emitted by the LLM.
+The sequence diagram highlights the concrete API calls triggered when you run the bundled CLI.
 
-## Extending
+```mermaid
+sequenceDiagram
+    participant Dev as Developer
+    participant CLI as CLI Runner
+    participant Pipe as Pipeline
+    participant GPT as GPT Coder
+    participant CLAUDE as Claude Coder
+    participant Ruff as Ruff Formatter
+    participant Pytest as Pytest Runner
+    participant Gemini as Gemini QA
 
-Modify `pipeline.py` to add new agent steps or alter the iteration logic. New tasks can be exposed to the MCP server by registering them in `run.py`.
+    Dev->>CLI: Provide coding task
+    CLI->>Pipe: pipeline.run(task)
+    Pipe->>GPT: run(state)
+    GPT-->>Pipe: proposed_code
+    Pipe->>CLAUDE: run(state)
+    CLAUDE-->>Pipe: refined proposed_code
+    Pipe->>Ruff: run(state)
+    Ruff-->>Pipe: formatted proposed_code
+    Pipe->>Pytest: run(state)
+    Pytest-->>Pipe: tests_passed + test_output
+    Pipe->>Gemini: run(state)
+    Gemini-->>Pipe: qa_passed + qa_output
+    Pipe-->>CLI: status + feedback
+    CLI-->>Dev: Summarise outcome
+```
 
-## Tests
+The state machine makes the retry logic explicit so you can reason about success and failure conditions.
 
-Run the built-in checks to verify that the pipeline operates correctly:
+```mermaid
+stateDiagram-v2
+    [*] --> Drafting
+    Drafting --> Drafting: Additional coder agents
+    Drafting --> Formatting
+    Formatting --> Testing
+    Testing --> Drafting: tests_passed = false
+    Testing --> QA: tests_passed = true
+    QA --> Drafting: qa_passed = false
+    QA --> Completed: qa_passed = true
+    Drafting --> Failed: proposed_code is empty
+    QA --> Failed: retries exhausted
+    Testing --> Failed: retries exhausted
+    Completed --> [*]
+    Failed --> [*]
+```
+
+```text
+Task
+  │
+  ▼
+AgenticCodingPipeline (max 3 iterations)
+  │  shared dict state: {task, proposed_code, tests_passed, qa_passed, feedback, ...}
+  ▼
+Coding agents (OpenAI + Claude)
+  │  produce / refine `proposed_code`
+  ▼
+Formatting agents (Ruff --fix)
+  │  normalize style before verification
+  ▼
+Testing agents (Claude writes tests → pytest run)
+  │  set `tests_passed`, attach `test_output`
+  ▼
+QA agents (Gemini review)
+  │  set `qa_passed`, attach `qa_output`
+  ▼
+Completion → `status="completed"` or loop with feedback until max iterations
+```
+
+---
+
+## Prerequisites
+
+* **Python 3.10+** (matches the rest of the Agentic AI monorepo).
+* **Local tooling** available on `$PATH`:
+  * `ruff` for formatting.
+  * `pytest` for executing generated suites.
+* **LLM credentials** (set as environment variables):
+  * `OPENAI_API_KEY` for GPT coders.
+  * `ANTHROPIC_API_KEY` for Claude coders/testers.
+  * `GOOGLE_API_KEY` for Gemini QA review.
+* **Clean git workspace** if you want to auto-commit results with the helper in `tools/git.py`.
+
+---
+
+## Install
 
 ```bash
-ruff check .
-pytest tests/test_pipeline.py
+# 1. Create an isolated environment
+python -m venv .venv
+source .venv/bin/activate  # Windows: .venv\Scripts\activate
+
+# 2. Install repo dependencies and developer tooling
+pip install --upgrade pip
+pip install -e .           # exposes shared agentic_ai clients
+pip install ruff pytest    # ensure local tools are present on PATH
 ```
+
+Prefer Poetry? Swap the virtualenv commands with:
+
+```bash
+poetry install
+poetry shell
+```
+
+---
+
+## Configure
+
+Set credentials as environment variables (or drop them into a `.env` loaded by your shell):
+
+```bash
+export OPENAI_API_KEY=sk-...
+export ANTHROPIC_API_KEY=sk-...
+export GOOGLE_API_KEY=sk-...
+```
+
+Each agent reads from these keys when instantiated, so they must be available before running the CLI or creating the pipeline.
+
+### Configuration reference
+
+| Knob | Where to set | Default | Effect |
+| ---- | ------------ | ------- | ------ |
+| `OPENAI_API_KEY` | env var | – | Authenticates the GPT-based `CodingAgent`. |
+| `ANTHROPIC_API_KEY` | env var | – | Powers the Claude-based coder and testing agent. |
+| `GOOGLE_API_KEY` | env var | – | Enables Gemini QA review verdicts. |
+| `max_iterations` | `AgenticCodingPipeline(max_iterations=...)` | `3` | Caps retries before marking the run as failed. |
+| `coders`/`formatters`/`testers`/`reviewers` | Constructor args | see CLI defaults | Controls which agents participate in the loop. |
+
+---
+
+## Run
+
+### CLI (batteries included)
+
+```bash
+cd Agentic-AI-Pipeline/Agentic-Coding-Pipeline
+python run.py "Add pagination support to the API client"
+```
+
+The CLI wires up OpenAI + Claude coders, a Ruff formatter, Claude-powered tester, and Gemini reviewer in one command.
+The script prints the final status and any captured feedback (failed tests, QA findings) for quick triage.
+
+### Programmatic usage
+
+```python
+from agents.coding import CodingAgent
+from agents.formatting import FormattingAgent
+from agents.testing import TestingAgent
+from agents.qa import QAAgent
+from pipeline import AgenticCodingPipeline
+
+pipeline = AgenticCodingPipeline(
+    coders=[CodingAgent(name="gpt"), CodingAgent(name="claude")],
+    formatters=[FormattingAgent(name="formatter")],
+    testers=[TestingAgent(name="tests")],
+    reviewers=[QAAgent(name="qa")],
+    max_iterations=5,
+)
+result = pipeline.run("Implement a prime sieve")
+print(result["status"], result.get("feedback"))
+```
+
+The return value is a serializable dict suitable for downstream orchestration (CI jobs, MCP routing, etc.).
+
+---
+
+## Control room UI
+
+The repo now ships with a **FastAPI + static web UI** so you can drive the same multi-agent loop from a browser.
+It mirrors the RAG pipeline control room: a glowing stage timeline, conversational transcript, and hitl gating buttons.
+
+### Start the server
+
+```bash
+cd Agentic-AI-Pipeline/Agentic-Coding-Pipeline
+uvicorn ui.server:app --reload --port 8000
+```
+
+Navigate to <http://localhost:8000>. The launcher banner accepts the high-level mission, then the UI streams each stage.
+
+### What the UI provides
+
+* **Chat-based control room** – every agent turn (coders, formatter, tester, QA) is narrated in the right-hand transcript with code/test logs attached inline.
+* **Stage timeline** – the left column shows live status chips (pending, awaiting human, running, failed, done) so you always know which gate is active.
+* **Human-in-the-loop controls** – approve or request revisions after the coding pass, choose when to run tests, and decide when to hand off to QA.
+* **Artifacts at a glance** – code previews, pytest output, and QA notes are stored in each stage card for quick auditing.
+
+### Workflow in the browser
+
+1. **Launch a mission** with a task (e.g., "Add retry logic to the webhook client").
+2. **Review coder output** in the chat stream; request revisions with inline feedback or approve to continue.
+3. **Gate automation** – trigger pytest when satisfied; if failures occur, the timeline reopens the human review stage with logs.
+4. **Send to QA** only after tests are green; QA verdicts and release notes appear in the chat.
+5. **Start another build** directly from the workspace once the pipeline reaches the Completed state.
+
+### HTTP endpoints
+
+| Method & path | Description |
+| ------------- | ----------- |
+| `POST /api/sessions` | Launch a new coding mission; returns session id, chat history, and stage metadata. |
+| `GET /api/sessions/{id}` | Fetch the latest state (useful for external dashboards or polling). |
+| `POST /api/sessions/{id}/feedback` | Submit human feedback: `approve` to continue or `revise` with notes to rerun coders. |
+| `POST /api/sessions/{id}/advance` | Advance automation gates (`run_tests` or `send_to_qa`). |
+
+### Front-end layout
+
+Static assets live in `ui/static/`:
+
+* `index.html` – shell with hero banner, timeline column, and chat panel.
+* `styles.css` – gradient aesthetic, stage badges, message formatting, toasts, and responsive behaviour.
+* `app.js` – fetches API endpoints, renders markdown/code blocks, and wires review/test/QA controls.
+
+---
+
+## How it works (step-by-step)
+
+1. **Task ingestion** – CLI seeds a shared state dict with the human request.
+2. **First coder pass** – GPT-based agent drafts an initial solution (or improves an existing snippet).
+3. **Second coder pass** – Claude-based agent refines the proposal, incorporating earlier feedback or failures.
+4. **Formatter pass** – Ruff auto-fixes lint/style deviations before any tests run.
+5. **Test synthesis** – Claude drafts pytest suites tailored to the generated code.
+6. **Local execution** – Pytest runs in an isolated temp directory; stdout/stderr are captured for diagnostics.
+7. **QA verdict** – Gemini reviews the candidate patch, emitting PASS/FAIL plus commentary.
+8. **Loop or finish** – Failures store feedback and trigger another iteration (up to `max_iterations`).
+
+---
+
+## State contract
+
+The shared state dictionary evolves as agents run. Understanding the keys makes it easy to plug in dashboards or custom logic.
+
+| Key | Producer | Consumer(s) | Description |
+| --- | -------- | ----------- | ----------- |
+| `task` | CLI / caller | All agents | Original human request seeded at pipeline start. |
+| `proposed_code` | Coding agents, formatter | Testers, reviewers | Latest candidate solution being evaluated. |
+| `tests_passed` | Testing agents | Orchestrator loop | Boolean signal to continue to QA. Failures trigger iteration feedback. |
+| `test_output` | Testing agents | Humans / coders | Raw pytest stdout+stderr, preserved for diagnosis or re-prompting. |
+| `qa_passed` | QA agents | Orchestrator loop | Indicates whether QA cleared the change. |
+| `qa_output` | QA agents | Humans / coders | Reviewer commentary (PASS or actionable issues). |
+| `feedback` | Orchestrator | Coders, humans | When tests/QA fail, the orchestrator surfaces the raw output as feedback for the next iteration. |
+| `status` | Orchestrator | Callers | Final lifecycle marker: `completed` or `failed`. |
+| `reason` | Orchestrator | Callers | Populated when a coder agent returns no code to explain the early failure. |
+
+---
+
+## Project structure
+
+```
+Agentic-Coding-Pipeline/
+├── README.md                     # This guide
+├── __init__.py                   # Package marker
+├── pipeline.py                   # Iterative orchestration logic
+├── run.py                        # CLI entry point
+├── ui/                           # Chat-based control room
+│   ├── server.py                 # FastAPI app exposing REST endpoints + static assets
+│   ├── session.py                # Human-in-loop session state machine
+│   └── static/                   # HTML/CSS/JS for the control room
+├── agents/                       # Role-specific LLM wrappers
+│   ├── base.py                   # Agent protocol + base dataclass
+│   ├── coding.py                 # Code synthesis agents
+│   ├── formatting.py             # Ruff-backed formatter agent
+│   ├── testing.py                # Test generation + execution agent
+│   └── qa.py                     # LLM review agent
+├── tools/                        # Optional utilities
+│   ├── git.py                    # git commit helper
+│   └── test_runner.py            # Standalone pytest runner helper
+└── tests/
+    └── test_pipeline.py          # Orchestration regression tests
+```
+
+---
+
+## Agents (roles & prompts)
+
+| Role | Default LLM client | Prompt strategy | Key state inputs | Key outputs |
+| ---- | ------------------ | --------------- | ---------------- | ----------- |
+| `CodingAgent` | `OpenAIClient` / `ClaudeClient` | Seed or improve a Python solution depending on whether `proposed_code` already exists. | `task`, `proposed_code` | Updated `proposed_code` |
+| `FormattingAgent` | Ruff CLI | Runs `ruff --fix` against a temp file and reloads the formatted contents. | `proposed_code` | Normalized `proposed_code` |
+| `TestingAgent` | `ClaudeClient` | Generates pytest suites covering the solution, executes them, and stores stdout/stderr. | `proposed_code` | `tests_passed`, `test_output` |
+| `QAAgent` | `GeminiClient` | Requests a PASS/FAIL verdict with commentary on issues found. | `proposed_code` | `qa_passed`, `qa_output` |
+
+All agents share the lightweight `Agent` protocol, so custom roles (docs writers, security scanners, benchmark runners) can drop in without changing the orchestrator.
+
+---
+
+## Prompt reference
+
+Understanding default prompt templates helps tailor model behaviour.
+
+* **Initial synthesis** – "Write a single Python function solving the following task. Return only code."
+* **Refinement** – "Improve the following Python code to better accomplish the task" (includes task and current code).
+* **Test authoring** – "Write pytest tests for the following Python code. Return only the test file contents."
+* **QA review** – "Respond with PASS if the code is acceptable, otherwise describe the problems."
+
+Swap or augment these strings in custom agents to target different languages, frameworks, or review policies.
+
+---
+
+## Test orchestration
+
+* **Isolation by temp directory** – Generated code and tests live in a throwaway workspace, keeping your repo pristine.
+* **Pytest integration** – Subprocess execution captures stdout/stderr, storing them in `test_output` for debugging or feedback to coders.
+* **Standalone helpers** – Import `tools.test_runner.run_pytest()` if you need to reuse the execution primitive in bespoke agents or CI hooks.
+* **Regression coverage** – `tests/test_pipeline.py` mocks the LLMs to validate that the orchestrator converges on a completed state.
+
+---
+
+## Formatting & patch hygiene
+
+* Ruff auto-fix keeps stylistic feedback out of the LLM loop and reduces diff churn.
+* Capture formatted snippets with git helpers for deterministic commits:
+
+  ```python
+  from tools.git import commit
+  commit(["path/to/file.py"], "feat: apply automated patch")
+  ```
+
+  The helper stages provided paths and creates a commit using standard git plumbing.
+
+* Pair the helper with `status` checks to build unattended pipelines (e.g., auto-PR bots) once QA passes.
+
+---
+
+## Tooling & integration patterns
+
+* **CLI orchestration** – `run.py` demonstrates how to wire agents with explicit LLM clients, making it easy to lift into Airflow, Dagster, or bespoke schedulers.
+* **Custom retries** – Wrap `pipeline.run()` and inspect `feedback` to implement exponential backoff, diff-based heuristics, or fallback model selection.
+* **CI hooks** – Use the returned dict in a job step to decide whether to push commits, request reviews, or fail fast. The bundled unit test shows how to swap LLMs for mocks when running in headless CI.
+* **Artifact capture** – Persist `proposed_code`, `test_output`, and `qa_output` to S3 or issue comments to give humans full context on automated changes.
+
+---
+
+## MCP integration
+
+This pipeline registers with the shared [`mcp`](../mcp) package. The FastAPI-backed **MCPServer** exposes a unified toolbox (web search, browsing, direct LLM calls) so any pipeline in the monorepo can dispatch coding tasks remotely or as part of a larger workflow.
+
+To plug this pipeline into the MCP network:
+
+1. Import `AgenticCodingPipeline` in your MCP task handler.
+2. Instantiate agents with the credentials available inside the MCP worker pod (often via Kubernetes secrets).
+3. Invoke `pipeline.run(task)` and route the resulting state (status, feedback, artifacts) back to the caller or next graph node.
+4. Optionally mount shared storage so test artifacts or generated files persist across MCP tool invocations.
+
+---
+
+## Extending & customization
+
+* **Swap models** – Pass alternative `LLMClient` implementations when constructing agents (e.g., Azure OpenAI, local models).
+* **Add new stages** – Extend the `formatters`, `testers`, or `reviewers` lists with additional agents (docs generation, security scans, benchmarks).
+* **Adjust iteration policy** – Change `max_iterations` or inject heuristics (stop early on repeated identical feedback, escalate on critical QA failures).
+* **Augment state** – Agents can read/write arbitrary keys; use this to track metrics, diff metadata, or artifact paths.
+* **Scale to multi-file edits** – Store structured payloads in `proposed_code` (e.g., dict of path → content) and customize formatter/tester agents accordingly.
+* **Guardrails & policies** – Wrap coder outputs with static analyzers or allow/deny lists before tests run to catch dependency misuse or security issues.
+
+---
+
+## Operations & observability
+
+* **Logging** – Instrument agents to log prompts, tokens, and runtimes before returning updated state. The orchestration loop makes a single pass per agent, making it easy to emit structured logs around each stage.
+* **Metrics** – Track counts of completed vs. failed runs, retry depth, and durations between state transitions. State keys (`tests_passed`, `qa_passed`) provide natural metric dimensions.
+* **Cost control** – Swap LLM clients or reduce `max_iterations` when cost thresholds are hit; fallback to cheaper coders or disable QA temporarily for low-risk changes.
+* **Safety** – Layer in secret-scanning agents or require QA PASS + human approval before calling `tools.git.commit` in production pipelines.
+
+---
+
+## Quality control & failure handling
+
+* Missing coder output immediately fails the run and surfaces a diagnostic so upstream orchestrators can react.
+* Test and QA failures attach their raw outputs to `feedback`, giving subsequent iterations or humans concrete guidance.
+* Exhausting the iteration budget marks the run as `failed`, preserving the last known state for inspection.
+* Unit tests validate that the orchestrator reaches a completed state with deterministic mock responses, preventing regressions in the loop contract.
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+| ------- | ------------ | --- |
+| `ModuleNotFoundError: agentic_ai.llm` | Repo dependencies not installed | Run `pip install -e .` from repo root or `poetry install`. |
+| `ruff: command not found` | Ruff not installed in current environment | `pip install ruff` or `poetry run ruff --version` to verify. |
+| Pytest exits with import errors | Generated code expects extra dependencies | Update prompts to constrain imports or pre-install needed packages. |
+| QA always fails with "PASS" missing | Reviewer prompt/casing changed | Ensure reviewer returns a string containing `PASS` on success or tweak condition accordingly. |
+| Pipeline stops after coder stage | An agent returned an empty string | Inspect `reason` for `"coder did not return code"` and adjust prompts or guardrails. |
+| Iterations never succeed | Feedback not consumed by coders | Make coder prompts reference `feedback` to incorporate failures when you extend the pipeline. |
+
+---
+
+## FAQ
+
+**Can I run only one coder?**  Yes. Provide a single `CodingAgent` (or even a custom agent) in the `coders` list.
+
+**How do I persist generated code to disk?**  Have an agent write `proposed_code` to the desired file path before QA, or call the git helper after completion.
+
+**Can the pipeline edit multi-file projects?**  The sample agents operate on a single code snippet, but the shared state supports richer payloads (e.g., dict of file paths). Add formatters/testers that understand your structure.
+
+**How do I integrate with CI?**  Wrap `AgenticCodingPipeline.run()` inside a job that prepares credentials and tools, then treat the returned state as the artifact for subsequent stages (commit, PR, deployment).
+
+**Where do I tweak prompts?**  Each agent defines its own prompt string—modify them directly or subclass the agent to inject dynamic templates.
+
+---
+
+Happy shipping! 🚀

--- a/Agentic-Coding-Pipeline/ui/server.py
+++ b/Agentic-Coding-Pipeline/ui/server.py
@@ -1,0 +1,91 @@
+"""FastAPI app serving the Agentic Coding Pipeline chat UI."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, Field
+
+from .session import store
+
+STATIC_DIR = Path(__file__).parent / "static"
+
+app = FastAPI(title="Agentic Coding Pipeline UI", version="1.0.0")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+class CreateSessionRequest(BaseModel):
+    task: str = Field(..., min_length=5, description="High level coding goal")
+
+
+class FeedbackRequest(BaseModel):
+    action: Literal["approve", "revise"]
+    comment: str | None = Field(default=None, description="Optional feedback or review notes")
+
+
+class AdvanceRequest(BaseModel):
+    action: Literal["run_tests", "send_to_qa"]
+
+
+@app.post("/api/sessions")
+def create_session(payload: CreateSessionRequest) -> dict:
+    session = store.create(payload.task)
+    return session.to_dict()
+
+
+@app.get("/api/sessions/{session_id}")
+def get_session(session_id: str) -> dict:
+    try:
+        return store.serialize(session_id)
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+
+
+@app.post("/api/sessions/{session_id}/feedback")
+def send_feedback(session_id: str, payload: FeedbackRequest) -> dict:
+    try:
+        session = store.get(session_id)
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+
+    try:
+        session.apply_feedback(payload.action, payload.comment)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return session.to_dict()
+
+
+@app.post("/api/sessions/{session_id}/advance")
+def advance(session_id: str, payload: AdvanceRequest) -> dict:
+    try:
+        session = store.get(session_id)
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+
+    if payload.action == "run_tests":
+        if session.stage_pointer != "testing":
+            raise HTTPException(status_code=409, detail="Testing stage not ready")
+        session.run_tests()
+    elif payload.action == "send_to_qa":
+        if session.stage_pointer != "qa":
+            raise HTTPException(status_code=409, detail="QA stage not ready")
+        session.run_qa()
+    return session.to_dict()
+
+
+@app.get("/")
+def index() -> FileResponse:
+    return FileResponse(STATIC_DIR / "index.html")
+
+
+app.mount("/assets", StaticFiles(directory=STATIC_DIR), name="assets")

--- a/Agentic-Coding-Pipeline/ui/session.py
+++ b/Agentic-Coding-Pipeline/ui/session.py
@@ -1,0 +1,367 @@
+"""Session orchestration helpers for the Agentic Coding Pipeline UI."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Dict, List
+from uuid import uuid4
+
+from agents.coding import CodingAgent
+from agents.formatting import FormattingAgent
+from agents.qa import QAAgent
+from agents.testing import TestingAgent
+from pipeline import AgenticCodingPipeline
+
+from agentic_ai.llm import ClaudeClient, GeminiClient, OpenAIClient
+
+
+class StageStatus(str, Enum):
+    """Simple status tags for the front-end timeline."""
+
+    PENDING = "pending"
+    ACTIVE = "active"
+    AWAITING = "awaiting"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass
+class TimelineStage:
+    """Track progress for a pipeline stage."""
+
+    id: str
+    title: str
+    description: str
+    status: StageStatus = StageStatus.PENDING
+    artifacts: Dict[str, object] = field(default_factory=dict)
+    feedback: str | None = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "status": self.status.value,
+            "artifacts": self.artifacts,
+            "feedback": self.feedback,
+        }
+
+
+@dataclass
+class ChatMessage:
+    """Representation of a chat message for the UI."""
+
+    role: str
+    content: str
+    stage: str | None = None
+    kind: str = "message"
+    timestamp: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(timespec="seconds")
+    )
+    attachments: Dict[str, object] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "role": self.role,
+            "content": self.content,
+            "stage": self.stage,
+            "kind": self.kind,
+            "timestamp": self.timestamp,
+            "attachments": self.attachments,
+        }
+
+
+class CodingPipelineSession:
+    """Stateful controller that advances the coding pipeline stage-by-stage."""
+
+    def __init__(self, task: str):
+        self.id = str(uuid4())
+        self.task = task.strip()
+        self.base_task = self.task
+        self.pipeline = AgenticCodingPipeline(
+            coders=[
+                CodingAgent(name="gpt-coder", llm=OpenAIClient()),
+                CodingAgent(name="claude-coder", llm=ClaudeClient()),
+            ],
+            formatters=[FormattingAgent(name="formatter")],
+            testers=[TestingAgent(name="tester", llm=ClaudeClient())],
+            reviewers=[QAAgent(name="qa", llm=GeminiClient())],
+        )
+        self.instructions: List[str] = []
+        self.state: Dict[str, object] = {"task": self.task}
+        self.messages: List[ChatMessage] = [
+            ChatMessage(role="user", content=self.task, stage="intake", kind="task")
+        ]
+        self.timeline = [
+            TimelineStage(
+                id="coding",
+                title="Multimodel Coding",
+                description="Two specialist coders draft or revise the implementation in parallel.",
+            ),
+            TimelineStage(
+                id="review",
+                title="Human-in-the-loop Review",
+                description="You inspect the diff, annotate issues, and decide whether to rerun the coders.",
+            ),
+            TimelineStage(
+                id="formatting",
+                title="Auto Formatting",
+                description="Style and structure corrections ensure the patch is clean and readable.",
+            ),
+            TimelineStage(
+                id="testing",
+                title="Test Orchestration",
+                description="Pytest suites are generated and executed when you green-light the run.",
+            ),
+            TimelineStage(
+                id="qa",
+                title="LLM QA Review",
+                description="A QA agent double-checks requirements and summarizes shipping notes.",
+            ),
+        ]
+        self.stage_pointer = "coding"
+        self.timeline[0].status = StageStatus.ACTIVE
+        self.run_coders()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _update_stage(self, stage_id: str, **changes: object) -> None:
+        for stage in self.timeline:
+            if stage.id == stage_id:
+                for key, value in changes.items():
+                    setattr(stage, key, value)
+                return
+        raise ValueError(f"Unknown stage id: {stage_id}")
+
+    def _get_stage(self, stage_id: str) -> TimelineStage:
+        for stage in self.timeline:
+            if stage.id == stage_id:
+                return stage
+        raise ValueError(f"Unknown stage id: {stage_id}")
+
+    def _append_message(
+        self,
+        role: str,
+        content: str,
+        *,
+        stage: str | None = None,
+        kind: str = "message",
+        attachments: Dict[str, object] | None = None,
+    ) -> None:
+        self.messages.append(
+            ChatMessage(
+                role=role,
+                content=content,
+                stage=stage,
+                kind=kind,
+                attachments=attachments or {},
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Stage runners
+    def run_coders(self) -> None:
+        """Execute all coder agents and capture their proposals."""
+
+        self.stage_pointer = "review"
+        stage = self._get_stage("coding")
+        stage.status = StageStatus.ACTIVE
+        proposals: Dict[str, str] = {}
+        for coder in self.pipeline.coders:
+            result = coder.run(self.state)
+            self.state.update(result)
+            proposals[coder.name] = str(self.state.get("proposed_code", "")).strip()
+        stage.status = StageStatus.COMPLETED
+        stage.artifacts = {
+            "proposed_code": self.state.get("proposed_code"),
+            "coders": proposals,
+        }
+        summary_lines = [
+            "The coding swarm produced a candidate implementation.",
+        ]
+        for name, snippet in proposals.items():
+            preview = snippet.splitlines()[:12]
+            formatted = "\n".join(preview)
+            summary_lines.append(f"**{name}** preview:\n```python\n{formatted}\n```")
+        self._append_message(
+            "assistant",
+            "\n\n".join(summary_lines),
+            stage="coding",
+            kind="stage-update",
+            attachments=stage.artifacts,
+        )
+        self._update_stage("review", status=StageStatus.AWAITING)
+
+    def apply_feedback(self, action: str, comment: str | None = None) -> None:
+        """Handle human review decisions and optionally rerun the coders."""
+
+        action = action.lower()
+        comment = (comment or "").strip()
+        if action not in {"approve", "revise"}:
+            raise ValueError("action must be either 'approve' or 'revise'")
+
+        if comment:
+            self.instructions.append(comment)
+            self._append_message("user", comment, stage="review", kind="feedback")
+
+        review_stage = self._get_stage("review")
+        if action == "revise":
+            review_stage.status = StageStatus.ACTIVE
+            self._update_stage("coding", status=StageStatus.ACTIVE)
+            enriched_task = self.base_task
+            if self.instructions:
+                enriched_task += "\n\nHuman feedback:\n" + "\n".join(
+                    f"- {item}" for item in self.instructions
+                )
+            self.state["task"] = enriched_task
+            self.run_coders()
+            return
+
+        # Approve path
+        review_stage.status = StageStatus.COMPLETED
+        self._update_stage("formatting", status=StageStatus.ACTIVE)
+        self.run_formatters()
+
+    def run_formatters(self) -> None:
+        stage = self._get_stage("formatting")
+        formatted_versions: Dict[str, str] = {}
+        for formatter in self.pipeline.formatters:
+            result = formatter.run(self.state)
+            self.state.update(result)
+            formatted_versions[formatter.name] = str(self.state.get("proposed_code", ""))
+        stage.status = StageStatus.COMPLETED
+        stage.artifacts = {
+            "formatted_code": self.state.get("proposed_code"),
+            "formatters": formatted_versions,
+        }
+        self._append_message(
+            "assistant",
+            "Formatter agents polished the code and synchronized style checks.",
+            stage="formatting",
+            kind="stage-update",
+            attachments=stage.artifacts,
+        )
+        self._update_stage("testing", status=StageStatus.AWAITING)
+        self.stage_pointer = "testing"
+
+    def run_tests(self) -> None:
+        stage = self._get_stage("testing")
+        stage.status = StageStatus.ACTIVE
+        aggregated_output: List[str] = []
+        tests_passed = True
+        for tester in self.pipeline.testers:
+            result = tester.run(self.state)
+            self.state.update(result)
+            aggregated_output.append(str(self.state.get("test_output", "")))
+            if not self.state.get("tests_passed"):
+                tests_passed = False
+        combined_output = "\n".join(aggregated_output).strip()
+        stage.artifacts = {
+            "tests_passed": tests_passed,
+            "test_output": combined_output,
+        }
+        if tests_passed:
+            stage.status = StageStatus.COMPLETED
+            self._append_message(
+                "assistant",
+                "✅ Automated tests passed. You're clear to send the patch to QA.",
+                stage="testing",
+                kind="stage-update",
+                attachments=stage.artifacts,
+            )
+            self._update_stage("qa", status=StageStatus.AWAITING)
+            self.stage_pointer = "qa"
+        else:
+            stage.status = StageStatus.FAILED
+            self._append_message(
+                "assistant",
+                "❌ Tests failed. Review the logs and send feedback for another coding pass.",
+                stage="testing",
+                kind="stage-update",
+                attachments=stage.artifacts,
+            )
+            self._update_stage("review", status=StageStatus.AWAITING)
+            self.stage_pointer = "review"
+
+    def run_qa(self) -> None:
+        stage = self._get_stage("qa")
+        stage.status = StageStatus.ACTIVE
+        qa_reports: Dict[str, str] = {}
+        all_passed = True
+        for reviewer in self.pipeline.reviewers:
+            result = reviewer.run(self.state)
+            self.state.update(result)
+            qa_reports[reviewer.name] = str(self.state.get("qa_output", ""))
+            if not self.state.get("qa_passed"):
+                all_passed = False
+        stage.artifacts = {
+            "qa_passed": all_passed,
+            "qa_reports": qa_reports,
+        }
+        if all_passed:
+            stage.status = StageStatus.COMPLETED
+            self._append_message(
+                "assistant",
+                "🎉 QA approved the patch and compiled release notes.",
+                stage="qa",
+                kind="stage-update",
+                attachments=stage.artifacts,
+            )
+        else:
+            stage.status = StageStatus.FAILED
+            self._append_message(
+                "assistant",
+                "⚠️ QA flagged issues. Provide guidance to re-run the coders.",
+                stage="qa",
+                kind="stage-update",
+                attachments=stage.artifacts,
+            )
+            self._update_stage("review", status=StageStatus.AWAITING)
+            self.stage_pointer = "review"
+            return
+
+        self.stage_pointer = "complete"
+        self.state["status"] = "completed"
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "session_id": self.id,
+            "task": self.task,
+            "stage": self.stage_pointer,
+            "messages": [message.to_dict() for message in self.messages],
+            "timeline": [stage.to_dict() for stage in self.timeline],
+            "state": {
+                key: value
+                for key, value in self.state.items()
+                if key in {"status", "proposed_code", "tests_passed", "qa_passed", "feedback"}
+            },
+            "instructions": self.instructions,
+        }
+
+
+class SessionStore:
+    """In-memory store for active sessions."""
+
+    def __init__(self) -> None:
+        self._sessions: Dict[str, CodingPipelineSession] = {}
+
+    def create(self, task: str) -> CodingPipelineSession:
+        session = CodingPipelineSession(task)
+        self._sessions[session.id] = session
+        return session
+
+    def get(self, session_id: str) -> CodingPipelineSession:
+        if session_id not in self._sessions:
+            raise KeyError(session_id)
+        return self._sessions[session_id]
+
+    def serialize(self, session_id: str) -> Dict[str, object]:
+        return self.get(session_id).to_dict()
+
+
+store = SessionStore()
+"""Global session store used by the FastAPI app."""

--- a/Agentic-Coding-Pipeline/ui/static/app.js
+++ b/Agentic-Coding-Pipeline/ui/static/app.js
@@ -1,0 +1,299 @@
+const timelineEl = document.getElementById("timeline");
+const chatEl = document.getElementById("chat-stream");
+const controlsEl = document.getElementById("controls");
+const launcherForm = document.getElementById("task-launcher");
+const launcherButton = launcherForm.querySelector("button");
+const taskField = document.getElementById("task");
+
+let currentSession = null;
+
+const statusClassMap = {
+  pending: "stage--pending",
+  active: "stage--active",
+  awaiting: "stage--awaiting",
+  completed: "stage--completed",
+  failed: "stage--failed",
+};
+
+function escapeHtml(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderInlineMarkdown(text) {
+  let html = escapeHtml(text);
+  html = html.replace(/\*\*(.*?)\*\*/g, "<strong>$1</strong>");
+  html = html.replace(/`([^`]+)`/g, "<code>$1</code>");
+  html = html.replace(/\n/g, "<br>");
+  return html;
+}
+
+function renderMarkdown(text) {
+  const codeBlock = /```(\w+)?\n([\s\S]*?)```/g;
+  let lastIndex = 0;
+  let result = "";
+  let match;
+  while ((match = codeBlock.exec(text)) !== null) {
+    result += renderInlineMarkdown(text.slice(lastIndex, match.index));
+    const code = escapeHtml(match[2].trim());
+    result += `<pre><code>${code}</code></pre>`;
+    lastIndex = match.index + match[0].length;
+  }
+  result += renderInlineMarkdown(text.slice(lastIndex));
+  return result;
+}
+
+async function createSession(task) {
+  const response = await fetch("/api/sessions", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ task }),
+  });
+  if (!response.ok) {
+    const detail = await response.json().catch(() => ({}));
+    throw new Error(detail.detail || "Unable to create session");
+  }
+  return response.json();
+}
+
+async function sendFeedback(action, comment) {
+  const response = await fetch(`/api/sessions/${currentSession.session_id}/feedback`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action, comment }),
+  });
+  if (!response.ok) {
+    const detail = await response.json().catch(() => ({}));
+    throw new Error(detail.detail || "Unable to submit feedback");
+  }
+  return response.json();
+}
+
+async function advance(action) {
+  const response = await fetch(`/api/sessions/${currentSession.session_id}/advance`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action }),
+  });
+  if (!response.ok) {
+    const detail = await response.json().catch(() => ({}));
+    throw new Error(detail.detail || "Unable to advance session");
+  }
+  return response.json();
+}
+
+function renderTimeline(timeline) {
+  timelineEl.innerHTML = "";
+  timeline.forEach((stage) => {
+    const stageEl = document.createElement("article");
+    stageEl.className = `stage ${statusClassMap[stage.status] || ""}`;
+    stageEl.innerHTML = `
+      <h3>${stage.title}</h3>
+      <p>${stage.description}</p>
+      <small>${stage.status.replace(/-/g, " ")}</small>
+    `;
+    timelineEl.appendChild(stageEl);
+  });
+}
+
+function renderMessages(messages) {
+  chatEl.innerHTML = "";
+  messages.forEach((msg) => {
+    const article = document.createElement("article");
+    article.className = `message role-${msg.role}`;
+    const header = document.createElement("header");
+    const roleLabel = document.createElement("span");
+    roleLabel.textContent = msg.role === "assistant" ? "Agent swarm" : "You";
+    const stamp = document.createElement("span");
+    stamp.textContent = new Date(msg.timestamp).toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+    header.appendChild(roleLabel);
+    header.appendChild(stamp);
+
+    const content = document.createElement("div");
+    content.className = "content";
+    content.innerHTML = renderMarkdown(msg.content);
+
+    article.appendChild(header);
+    article.appendChild(content);
+
+    if (msg.attachments && msg.attachments.proposed_code) {
+      const pre = document.createElement("pre");
+      pre.innerText = msg.attachments.proposed_code;
+      article.appendChild(pre);
+    }
+
+    if (msg.attachments && msg.attachments.test_output) {
+      const pre = document.createElement("pre");
+      pre.innerText = msg.attachments.test_output;
+      article.appendChild(pre);
+    }
+
+    if (msg.attachments && msg.attachments.qa_reports) {
+      Object.entries(msg.attachments.qa_reports).forEach(([agent, report]) => {
+        const block = document.createElement("pre");
+        block.innerText = `${agent}:\n${report}`;
+        article.appendChild(block);
+      });
+    }
+
+    chatEl.appendChild(article);
+  });
+  chatEl.scrollTop = chatEl.scrollHeight;
+}
+
+function showError(message) {
+  const existing = document.querySelector(".toast");
+  if (existing) existing.remove();
+  const toast = document.createElement("div");
+  toast.className = "toast";
+  toast.textContent = message;
+  document.body.appendChild(toast);
+  setTimeout(() => toast.remove(), 4200);
+}
+
+function renderControls(session) {
+  controlsEl.innerHTML = "";
+  if (!session) {
+    controlsEl.innerHTML = '<p class="hint">Launch a mission to unlock human review controls.</p>';
+    return;
+  }
+
+  if (session.stage === "review") {
+    controlsEl.innerHTML = `
+      <p class="hint">Review the agents' proposal. Request a revision with notes or approve to continue.</p>
+      <textarea id="feedback" placeholder="e.g. Cover edge cases for empty payloads and add docstrings"></textarea>
+      <div class="button-row">
+        <button class="button secondary" id="revise">Request revision</button>
+        <button class="button primary" id="approve">Approve & continue</button>
+      </div>
+    `;
+    const feedback = document.getElementById("feedback");
+    document.getElementById("revise").addEventListener("click", async () => {
+      if (!feedback.value.trim()) {
+        feedback.focus();
+        showError("Add feedback before requesting another coding pass.");
+        return;
+      }
+      try {
+        controlsEl.classList.add("busy");
+        currentSession = await sendFeedback("revise", feedback.value.trim());
+        renderAll();
+      } catch (error) {
+        showError(error.message);
+      } finally {
+        controlsEl.classList.remove("busy");
+      }
+    });
+    document.getElementById("approve").addEventListener("click", async () => {
+      try {
+        controlsEl.classList.add("busy");
+        currentSession = await sendFeedback("approve", feedback.value.trim() || undefined);
+        renderAll();
+      } catch (error) {
+        showError(error.message);
+      } finally {
+        controlsEl.classList.remove("busy");
+      }
+    });
+    return;
+  }
+
+  if (session.stage === "testing") {
+    controlsEl.innerHTML = `
+      <p class="hint">Trigger automated regression tests when you're ready.</p>
+      <div class="button-row">
+        <button class="button primary" id="run-tests">Run tests</button>
+      </div>
+    `;
+    document.getElementById("run-tests").addEventListener("click", async () => {
+      try {
+        controlsEl.classList.add("busy");
+        currentSession = await advance("run_tests");
+        renderAll();
+      } catch (error) {
+        showError(error.message);
+      } finally {
+        controlsEl.classList.remove("busy");
+      }
+    });
+    return;
+  }
+
+  if (session.stage === "qa") {
+    controlsEl.innerHTML = `
+      <p class="hint">All checks are green. Forward the build to the QA agent for release notes.</p>
+      <div class="button-row">
+        <button class="button primary" id="run-qa">Send to QA</button>
+      </div>
+    `;
+    document.getElementById("run-qa").addEventListener("click", async () => {
+      try {
+        controlsEl.classList.add("busy");
+        currentSession = await advance("send_to_qa");
+        renderAll();
+      } catch (error) {
+        showError(error.message);
+      } finally {
+        controlsEl.classList.remove("busy");
+      }
+    });
+    return;
+  }
+
+  if (session.stage === "complete") {
+    controlsEl.innerHTML = `
+      <p class="hint">Pipeline complete. Run another mission from the launcher above.</p>
+      <div class="button-row">
+        <button class="button secondary" id="reset">Start another build</button>
+      </div>
+    `;
+    document.getElementById("reset").addEventListener("click", () => {
+      currentSession = null;
+      launcherForm.classList.remove("disabled");
+      launcherButton.disabled = false;
+      taskField.disabled = false;
+      renderAll();
+      chatEl.innerHTML = "";
+      timelineEl.innerHTML = "";
+    });
+    return;
+  }
+
+  controlsEl.innerHTML = '<p class="hint">The pipeline is processing… hang tight.</p>';
+}
+
+function renderAll() {
+  if (!currentSession) {
+    renderControls(null);
+    return;
+  }
+  renderTimeline(currentSession.timeline);
+  renderMessages(currentSession.messages);
+  renderControls(currentSession);
+}
+
+launcherForm.addEventListener("submit", async (event) => {
+  event.preventDefault();
+  const task = taskField.value.trim();
+  if (!task) return;
+  launcherButton.disabled = true;
+  taskField.disabled = true;
+  launcherForm.classList.add("disabled");
+  try {
+    currentSession = await createSession(task);
+    renderAll();
+  } catch (error) {
+    launcherButton.disabled = false;
+    taskField.disabled = false;
+    showError(error.message);
+  }
+});
+
+renderAll();

--- a/Agentic-Coding-Pipeline/ui/static/index.html
+++ b/Agentic-Coding-Pipeline/ui/static/index.html
@@ -1,0 +1,53 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Agentic Coding Pipeline Control Room</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;600&family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/assets/styles.css" />
+  </head>
+  <body>
+    <div class="background"></div>
+    <div class="app">
+      <header class="hero">
+        <div>
+          <p class="eyebrow">Bonus Tooling</p>
+          <h1>Agentic Coding Pipeline Control Room</h1>
+          <p class="lede">
+            Orchestrate coder, formatter, tester, and QA agents with human-in-the-loop checkpoints.
+            Launch a build request, review diff summaries, gate automated testing, and approve release notes
+            all inside a conversational workspace.
+          </p>
+        </div>
+        <form id="task-launcher" class="task-launcher" autocomplete="off">
+          <label for="task">New coding mission</label>
+          <textarea
+            id="task"
+            name="task"
+            placeholder="e.g. Add rate limiting middleware to the FastAPI gateway and expose metrics"
+            required
+          ></textarea>
+          <button type="submit">Spin up pipeline</button>
+        </form>
+      </header>
+
+      <main class="workspace">
+        <aside class="timeline" aria-label="Pipeline timeline">
+          <h2>Pipeline stages</h2>
+          <div id="timeline"></div>
+        </aside>
+        <section class="chat-panel" aria-label="Agent conversation">
+          <div id="chat-stream" class="chat-stream" aria-live="polite"></div>
+          <div class="controls" id="controls"></div>
+        </section>
+      </main>
+    </div>
+    <script type="module" src="/assets/app.js"></script>
+  </body>
+</html>

--- a/Agentic-Coding-Pipeline/ui/static/styles.css
+++ b/Agentic-Coding-Pipeline/ui/static/styles.css
@@ -1,0 +1,417 @@
+:root {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at top left, rgba(120, 80, 255, 0.35), transparent 55%),
+    radial-gradient(circle at bottom right, rgba(0, 220, 220, 0.25), transparent 45%),
+    #05060f;
+  --panel: rgba(17, 20, 34, 0.75);
+  --border: rgba(120, 134, 255, 0.25);
+  --accent: #7c5cff;
+  --accent-strong: #5b7bff;
+  --success: #3dd68c;
+  --danger: #ff6b81;
+  --text: #f5f6ff;
+  --subtle: #a9b1d6;
+  --code-bg: rgba(8, 10, 20, 0.9);
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.background {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(124, 92, 255, 0.35), rgba(0, 208, 255, 0.15));
+  opacity: 0.6;
+  filter: blur(120px);
+  z-index: -1;
+}
+
+.app {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 3.5rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.hero {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 3fr);
+  align-items: end;
+}
+
+.hero h1 {
+  margin: 0;
+  font-size: clamp(2.25rem, 2vw + 2rem, 3.5rem);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+}
+
+.hero .lede {
+  margin-top: 1rem;
+  color: var(--subtle);
+  font-size: 1.05rem;
+  line-height: 1.6;
+}
+
+.eyebrow {
+  display: inline-flex;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(124, 92, 255, 0.18);
+  color: var(--accent-strong);
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  margin-bottom: 0.75rem;
+}
+
+.task-launcher {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 20px;
+  padding: 1.75rem;
+  display: grid;
+  gap: 1rem;
+  box-shadow: 0 35px 65px rgba(5, 6, 15, 0.45);
+}
+
+.task-launcher label {
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--subtle);
+}
+
+.task-launcher textarea {
+  resize: vertical;
+  min-height: 120px;
+  max-height: 220px;
+  padding: 1rem 1.25rem;
+  border-radius: 16px;
+  border: 1px solid rgba(124, 92, 255, 0.25);
+  background: rgba(13, 16, 29, 0.9);
+  color: inherit;
+  font-size: 1rem;
+  line-height: 1.6;
+  font-family: "Inter", sans-serif;
+}
+
+.task-launcher textarea:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.task-launcher button {
+  justify-self: end;
+  padding: 0.9rem 1.8rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  font-weight: 600;
+  font-size: 1rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  box-shadow: 0 18px 30px rgba(124, 92, 255, 0.35);
+}
+
+.task-launcher button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 25px 40px rgba(124, 92, 255, 0.45);
+}
+
+.task-launcher button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  gap: 2rem;
+  align-items: start;
+}
+
+.timeline {
+  background: var(--panel);
+  border-radius: 26px;
+  border: 1px solid var(--border);
+  padding: 1.8rem;
+  display: grid;
+  gap: 1.2rem;
+  position: sticky;
+  top: 2.5rem;
+  max-height: calc(100vh - 5rem);
+  overflow-y: auto;
+}
+
+.timeline h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--subtle);
+}
+
+.stage {
+  padding: 1.1rem 1.2rem 1.1rem 1.4rem;
+  border-radius: 18px;
+  border: 1px solid rgba(124, 92, 255, 0.2);
+  background: rgba(16, 19, 33, 0.88);
+  transition: border-color 0.15s ease, background 0.2s ease;
+  position: relative;
+}
+
+.stage::before {
+  content: "";
+  position: absolute;
+  left: 0.75rem;
+  top: 1.3rem;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(124, 92, 255, 0.4);
+  box-shadow: 0 0 15px rgba(124, 92, 255, 0.65);
+}
+
+.stage h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.stage p {
+  margin: 0.5rem 0 0;
+  color: var(--subtle);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.stage small {
+  display: inline-flex;
+  margin-top: 0.7rem;
+  padding: 0.35rem 0.65rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(124, 92, 255, 0.18);
+  color: var(--accent-strong);
+}
+
+.stage--active {
+  border-color: rgba(124, 92, 255, 0.65);
+  background: rgba(29, 34, 59, 0.92);
+}
+
+.stage--awaiting::before {
+  background: rgba(255, 200, 120, 0.8);
+  box-shadow: 0 0 15px rgba(255, 200, 120, 0.7);
+}
+
+.stage--completed {
+  border-color: rgba(61, 214, 140, 0.55);
+}
+
+.stage--completed::before {
+  background: var(--success);
+  box-shadow: 0 0 18px rgba(61, 214, 140, 0.6);
+}
+
+.stage--failed {
+  border-color: rgba(255, 107, 129, 0.65);
+}
+
+.stage--failed::before {
+  background: var(--danger);
+  box-shadow: 0 0 16px rgba(255, 107, 129, 0.65);
+}
+
+.chat-panel {
+  display: grid;
+  gap: 1.2rem;
+  background: var(--panel);
+  border-radius: 28px;
+  border: 1px solid var(--border);
+  padding: 1.8rem;
+  min-height: 520px;
+  box-shadow: 0 30px 65px rgba(5, 6, 15, 0.55);
+}
+
+.chat-stream {
+  display: grid;
+  gap: 1rem;
+  max-height: 60vh;
+  overflow-y: auto;
+  padding-right: 0.5rem;
+}
+
+.message {
+  padding: 1rem 1.2rem;
+  border-radius: 18px;
+  border: 1px solid rgba(124, 92, 255, 0.18);
+  background: rgba(13, 15, 26, 0.9);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.message header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.message header span {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--subtle);
+}
+
+.message .content {
+  font-size: 0.98rem;
+  line-height: 1.6;
+  color: var(--text);
+}
+
+.message pre {
+  margin: 0;
+  background: var(--code-bg);
+  border-radius: 16px;
+  padding: 1rem 1.1rem;
+  overflow-x: auto;
+  font-family: "Fira Code", monospace;
+  font-size: 0.9rem;
+  border: 1px solid rgba(124, 92, 255, 0.2);
+}
+
+.message code {
+  font-family: "Fira Code", monospace;
+  background: rgba(124, 92, 255, 0.15);
+  padding: 0.15rem 0.35rem;
+  border-radius: 6px;
+  border: 1px solid rgba(124, 92, 255, 0.2);
+}
+
+.message.role-user {
+  border-color: rgba(255, 200, 120, 0.35);
+  background: rgba(24, 20, 9, 0.9);
+}
+
+.message.role-user header span {
+  color: rgba(255, 204, 153, 0.9);
+}
+
+.message.role-assistant {
+  border-color: rgba(124, 92, 255, 0.35);
+}
+
+.controls {
+  display: grid;
+  gap: 1rem;
+}
+
+.controls .hint {
+  color: var(--subtle);
+  font-size: 0.9rem;
+}
+
+.controls textarea {
+  width: 100%;
+  min-height: 120px;
+  border-radius: 18px;
+  border: 1px solid rgba(124, 92, 255, 0.25);
+  background: rgba(13, 16, 29, 0.9);
+  color: inherit;
+  padding: 1rem 1.25rem;
+  font-family: "Inter", sans-serif;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  resize: vertical;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button {
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  border: none;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button.primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: #fff;
+  box-shadow: 0 15px 30px rgba(124, 92, 255, 0.35);
+}
+
+.button.secondary {
+  background: rgba(124, 92, 255, 0.18);
+  color: var(--accent-strong);
+}
+
+.button.danger {
+  background: rgba(255, 107, 129, 0.2);
+  color: #ff9ba7;
+}
+
+.button:hover:not(:disabled) {
+  transform: translateY(-1px);
+}
+
+.button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 1024px) {
+  .hero {
+    grid-template-columns: 1fr;
+  }
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+  .timeline {
+    position: static;
+    max-height: none;
+  }
+}
+.controls.busy {
+  opacity: 0.6;
+  pointer-events: none;
+}
+
+.toast {
+  position: fixed;
+  right: 2rem;
+  bottom: 2rem;
+  padding: 0.85rem 1.4rem;
+  background: rgba(255, 107, 129, 0.92);
+  color: #fff;
+  border-radius: 999px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  box-shadow: 0 18px 30px rgba(255, 107, 129, 0.45);
+  z-index: 1000;
+}

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ The reference task baked into this repo is a **Research & Outreach Agent** (“*
 
 ## Bonus: Agentic Coding Pipeline
 
-Need an **autonomous coding assistant** that drafts patches, formats them, synthesizes tests, runs quality gates, and iterates until everything passes? The companion **Agentic Coding Pipeline** coordinates GPT + Claude coders, Ruff formatting, pytest execution, and Gemini QA review through the same shared MCP bus that powers the rest of this monorepo.【F:Agentic-Coding-Pipeline/run.py†L21-L33】【F:Agentic-Coding-Pipeline/agents/formatting.py†L17-L26】【F:Agentic-Coding-Pipeline/agents/testing.py†L26-L42】【F:Agentic-Coding-Pipeline/agents/qa.py†L23-L33】
+Need an **autonomous coding assistant** that drafts patches, formats them, synthesizes tests, runs quality gates, and iterates until everything passes? The companion **Agentic Coding Pipeline** coordinates GPT + Claude coders, Ruff formatting, pytest execution, and Gemini QA review through the same shared MCP bus that powers the rest of this monorepo.
 
 > [!TIP]
 > See **[Agentic-Coding-Pipeline Directory](Agentic-Coding-Pipeline/README.md)** for setup, architecture, and customization notes.
@@ -327,9 +327,9 @@ flowchart TD
   OR -. feedback .-> C2
 ```
 
-* **Multi-LLM pair programming** keeps GPT and Claude coders in lockstep via a shared state dictionary.【F:Agentic-Coding-Pipeline/run.py†L21-L33】【F:Agentic-Coding-Pipeline/pipeline.py†L21-L43】
-* **Tool-backed gates** ensure Ruff formatting, pytest verification, and Gemini QA review all pass before the pipeline returns success.【F:Agentic-Coding-Pipeline/agents/formatting.py†L17-L26】【F:Agentic-Coding-Pipeline/agents/testing.py†L26-L42】【F:Agentic-Coding-Pipeline/agents/qa.py†L23-L33】
-* **Iterative retry logic** loops until a completed state is reached or the max iteration budget is exhausted, surfacing feedback for humans or follow-up agents.【F:Agentic-Coding-Pipeline/pipeline.py†L33-L56】
+* **Multi-LLM pair programming** keeps GPT and Claude coders in lockstep via a shared state dictionary.
+* **Tool-backed gates** ensure Ruff formatting, pytest verification, and Gemini QA review all pass before the pipeline returns success.
+* **Iterative retry logic** loops until a completed state is reached or the max iteration budget is exhausted, surfacing feedback for humans or follow-up agents.
 
 ```bash
 cd Agentic-Coding-Pipeline

--- a/README.md
+++ b/README.md
@@ -304,14 +304,36 @@ The reference task baked into this repo is a **Research & Outreach Agent** (“*
 
 ## Bonus: Agentic Coding Pipeline
 
-Want an **autonomous coding assistant** that proposes patches, formats them, drafts tests, reviews code and iterates until everything passes? The companion **Agentic Coding Pipeline** orchestrates multi-model coding (OpenAI + Claude), formatting, testing and Gemini-based review through a shared MCP server so any pipeline can dispatch code tasks.
+Need an **autonomous coding assistant** that drafts patches, formats them, synthesizes tests, runs quality gates, and iterates until everything passes? The companion **Agentic Coding Pipeline** coordinates GPT + Claude coders, Ruff formatting, pytest execution, and Gemini QA review through the same shared MCP bus that powers the rest of this monorepo.【F:Agentic-Coding-Pipeline/run.py†L21-L33】【F:Agentic-Coding-Pipeline/agents/formatting.py†L17-L26】【F:Agentic-Coding-Pipeline/agents/testing.py†L26-L42】【F:Agentic-Coding-Pipeline/agents/qa.py†L23-L33】
 
 > [!TIP]
-> See **[Agentic-Coding-Pipeline Directory](Agentic-Coding-Pipeline/README.md)** for detailed usage and architecture.
+> See **[Agentic-Coding-Pipeline Directory](Agentic-Coding-Pipeline/README.md)** for setup, architecture, and customization notes.
+
+```mermaid
+flowchart TD
+  T[Developer Task] --> OR[AgenticCodingPipeline]
+  OR --> C1[GPT Coding Agent]
+  OR --> C2[Claude Coding Agent]
+  C1 --> OR
+  C2 --> OR
+  OR --> F[Ruff Formatter]
+  F --> OR
+  OR --> TS[Claude Test Author + Pytest Runner]
+  TS --> OR
+  OR --> QA[Gemini QA Reviewer]
+  QA -->|PASS?| OR
+  OR --> OUT[Ready-to-commit Patch]
+  OR -. feedback .-> C1
+  OR -. feedback .-> C2
+```
+
+* **Multi-LLM pair programming** keeps GPT and Claude coders in lockstep via a shared state dictionary.【F:Agentic-Coding-Pipeline/run.py†L21-L33】【F:Agentic-Coding-Pipeline/pipeline.py†L21-L43】
+* **Tool-backed gates** ensure Ruff formatting, pytest verification, and Gemini QA review all pass before the pipeline returns success.【F:Agentic-Coding-Pipeline/agents/formatting.py†L17-L26】【F:Agentic-Coding-Pipeline/agents/testing.py†L26-L42】【F:Agentic-Coding-Pipeline/agents/qa.py†L23-L33】
+* **Iterative retry logic** loops until a completed state is reached or the max iteration budget is exhausted, surfacing feedback for humans or follow-up agents.【F:Agentic-Coding-Pipeline/pipeline.py†L33-L56】
 
 ```bash
 cd Agentic-Coding-Pipeline
-python run.py "Add feature X"
+python run.py "Add pagination support to the API client"
 ```
 
 ## Quickstart


### PR DESCRIPTION
## Summary
- add a FastAPI session controller that exposes the coding pipeline through REST endpoints
- build a chat-based control room UI with stage timeline, human feedback controls, and rich styling
- document how to launch and use the browser UI from the Agentic Coding Pipeline README

## Testing
- `pytest Agentic-Coding-Pipeline/tests/test_pipeline.py` *(fails: pyenv reports Python 3.11.9 not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cf6b027bf8832cb7db1def40a51ef5