### PR TITLE
ci: add GHCR Docker image push to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,8 @@ jobs:
           name: logs-py${{ matrix.python-version }}
           path: .logs/
 
-  docker:
-    name: Docker build
+  docker-build:
+    name: "\U0001F433 Docker build + smoke test"
     runs-on: ubuntu-latest
     needs: test
     steps:
@@ -93,14 +93,39 @@ jobs:
             -e PYTHONPATH=/app/src \
             -p 8000:8000 \
             agentic-ai:ci
-          # Wait for startup
           for i in $(seq 1 20); do
             if curl -fsS http://127.0.0.1:8000/health; then
-              echo "Health OK"
+              echo " Health OK"
               break
             fi
             sleep 2
           done
-          # Verify health endpoint
           curl -f http://127.0.0.1:8000/health
           docker stop smoke
+
+  docker-ghcr:
+    name: "\U0001F433 Push to GHCR"
+    needs: [docker-build]
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          target: runtime
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/agentic-ai:${{ github.sha }}
+            ghcr.io/${{ github.repository_owner }}/agentic-ai:latest


### PR DESCRIPTION
This pull request updates the CI workflow to improve Docker build and deployment processes. The main changes include renaming and enhancing the Docker build job, adding a new job to push Docker images to GitHub Container Registry (GHCR), and streamlining the smoke test steps.

**Docker workflow improvements:**

* Renamed the `docker` job to `docker-build` and updated its name to include an emoji and clarify that it performs both the Docker build and smoke test.
* Streamlined the smoke test step by removing redundant comments and ensuring the health check is performed efficiently.

**Automated Docker image publishing:**

* Added a new `docker-ghcr` job that runs after a successful Docker build, logs into GHCR, and pushes both a SHA-tagged and a `latest` Docker image to the registry. This job only runs on push events and is configured with appropriate permissions.