### PR TITLE
feat: add Tavily web search as parallel option to DuckDuckGo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ ANTHROPIC_MODEL_CHAT=claude-3-5-sonnet-latest
 # --- Google Gemini (optional, used by MCP server) ---
 GOOGLE_API_KEY=
 
+# --- Search Provider ---
+SEARCH_PROVIDER=duckduckgo       # duckduckgo | tavily
+TAVILY_API_KEY=                  # Required when SEARCH_PROVIDER=tavily
+
 # --- Storage ---
 CHROMA_DIR=.chroma
 SQLITE_PATH=.sqlite/agent.db

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ typing-extensions>=4.12.2
 
 # Discovery
 duckduckgo-search>=6.2.10
+tavily-python>=0.3.0
 httpx>=0.27.0
 trafilatura>=1.10.0
 beautifulsoup4>=4.12.3

--- a/src/agentic_ai/layers/tools.py
+++ b/src/agentic_ai/layers/tools.py
@@ -6,8 +6,8 @@ from langchain.tools import BaseTool
 
 from ..tools.knowledge import KbAdd, KbSearch
 from ..tools.ops import Calculator, Emailer, FileWrite
-from ..tools.webtools import WebFetch, WebSearch
+from ..tools.webtools import WebFetch, get_web_search_tool
 
 
 def registry() -> List[BaseTool]:
-    return [WebSearch(), WebFetch(), KbSearch(), KbAdd(), Calculator(), FileWrite(), Emailer()]
+    return [get_web_search_tool(), WebFetch(), KbSearch(), KbAdd(), Calculator(), FileWrite(), Emailer()]

--- a/src/agentic_ai/tools/webtools.py
+++ b/src/agentic_ai/tools/webtools.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import os
 
 import httpx
 import trafilatura
@@ -21,6 +22,38 @@ class WebSearch(BaseTool):
         with DDGS() as d:
             results = d.text(query, max_results=8)
         return json.dumps(list(results), ensure_ascii=False)
+
+
+class TavilyWebSearch(BaseTool):
+    name: str = "web_search"
+    description: str = (
+        "Search the web. Input: a natural language query. "
+        "Output: JSON list of {title, url, snippet}."
+    )
+
+    @retry(stop=stop_after_attempt(3), wait=wait_exponential(multiplier=1, min=1, max=4))
+    def _run(self, query: str) -> str:
+        from tavily import TavilyClient
+
+        client = TavilyClient()
+        response = client.search(query=query, max_results=8)
+        results = [
+            {
+                "title": r.get("title", ""),
+                "url": r.get("url", ""),
+                "snippet": r.get("content", ""),
+            }
+            for r in response.get("results", [])
+        ]
+        return json.dumps(results, ensure_ascii=False)
+
+
+def get_web_search_tool() -> BaseTool:
+    """Return the active web search tool based on SEARCH_PROVIDER env var."""
+    provider = os.environ.get("SEARCH_PROVIDER", "duckduckgo").lower()
+    if provider == "tavily":
+        return TavilyWebSearch()
+    return WebSearch()
 
 
 class WebFetch(BaseTool):


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable search provider alongside the existing DuckDuckGo integration (additive/parallel strategy). Users can switch between providers via the `SEARCH_PROVIDER` environment variable. DuckDuckGo remains the default.

## Changes

- **`src/agentic_ai/tools/webtools.py`**: Added `TavilyWebSearch` LangChain `BaseTool` class that returns the same `{title, url, snippet}` JSON schema as the existing `WebSearch` tool. Added `get_web_search_tool()` factory function that reads `SEARCH_PROVIDER` env var to select the active tool at runtime.
- **`src/agentic_ai/layers/tools.py`**: Updated `registry()` to use `get_web_search_tool()` factory instead of directly instantiating `WebSearch`.
- **`requirements.txt`**: Added `tavily-python>=0.3.0`.
- **`.env.example`**: Added `SEARCH_PROVIDER` and `TAVILY_API_KEY` configuration entries.

## Dependency changes

- Added `tavily-python>=0.3.0` to `requirements.txt`

## Environment variable changes

- `SEARCH_PROVIDER` — optional, defaults to `duckduckgo`, set to `tavily` to use Tavily
- `TAVILY_API_KEY` — required when `SEARCH_PROVIDER=tavily`

## Notes for reviewers

- The existing `WebSearch` (DuckDuckGo) class is completely unchanged
- `tavily-python` is imported lazily inside `TavilyWebSearch._run()` to avoid import errors when Tavily is not the active provider
- Both tools share the same `name` (`web_search`) so they are interchangeable in the agent pipeline


### Automated Review

- Passed after 1 attempt(s)
- Final review: The migration correctly adds Tavily as a configurable parallel search provider alongside DuckDuckGo. All four reported files are modified appropriately: `TavilyWebSearch` tool class is implemented with consistent retry logic and output normalization, a `get_web_search_tool()` factory reads `SEARCH_PROVIDER` env var (defaulting to `duckduckgo`), `layers/tools.py` is updated to use the factory, `tavily-python>=0.3.0` is added to `requirements.txt`, and both new env vars are documented in `.env.example`. No regressions introduced — existing `WebSearch` class and DuckDuckGo path are fully preserved. Code style is consistent with the codebase. Only one minor issue noted.
