### PR TITLE
feat: migrate MCP server search to support Tavily alongside DuckDuckGo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ ANTHROPIC_MODEL_CHAT=claude-3-5-sonnet-latest
 # --- Google Gemini (optional, used by MCP server) ---
 GOOGLE_API_KEY=
 
+# --- Search Provider ---
+SEARCH_PROVIDER=duckduckgo     # duckduckgo | tavily
+TAVILY_API_KEY=                # Required when SEARCH_PROVIDER=tavily
+
 # --- Storage ---
 CHROMA_DIR=.chroma
 SQLITE_PATH=.sqlite/agent.db

--- a/mcp/server.py
+++ b/mcp/server.py
@@ -71,8 +71,8 @@ class MCPServer:
 
         @self.app.get("/search")
         async def search(q: str, max_results: int = 5) -> Dict[str, Any]:
-            """Perform a web search using DuckDuckGo."""
-            results = await webtools.search_ddg(q, max_results=max_results)
+            """Perform a web search."""
+            results = await webtools.search_web(q, max_results=max_results)
             return {"query": q, "results": results}
 
         @self.app.get("/browse")
@@ -84,7 +84,7 @@ class MCPServer:
         @self.app.get("/research")
         async def research(q: str, max_results: int = 3) -> Dict[str, Any]:
             """Conduct a search and fetch the contents of top results."""
-            results = await webtools.search_ddg(q, max_results=max_results)
+            results = await webtools.search_web(q, max_results=max_results)
             pages: List[Dict[str, str]] = []
             for res in results:
                 url = res.get("href") or res.get("url")

--- a/mcp/tools/web.py
+++ b/mcp/tools/web.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import httpx
 import trafilatura
 from bs4 import BeautifulSoup
@@ -12,6 +14,33 @@ async def search_ddg(q: str, max_results: int = 5):
             return list(ddgs.text(q, max_results=max_results))
         except Exception:
             return []
+
+
+async def search_tavily(q: str, max_results: int = 5):
+    """Search using the Tavily API, returning results normalised to {title, href, body}."""
+    from tavily import TavilyClient
+
+    client = TavilyClient(api_key=os.environ["TAVILY_API_KEY"])
+    try:
+        response = client.search(query=q, max_results=max_results)
+    except Exception:
+        return []
+    results = []
+    for r in response.get("results", []):
+        results.append({
+            "title": r.get("title", ""),
+            "href": r.get("url", ""),
+            "body": r.get("content", ""),
+        })
+    return results
+
+
+async def search_web(q: str, max_results: int = 5):
+    """Dispatch to the configured search provider (duckduckgo or tavily)."""
+    provider = os.environ.get("SEARCH_PROVIDER", "duckduckgo").lower()
+    if provider == "tavily":
+        return await search_tavily(q, max_results=max_results)
+    return await search_ddg(q, max_results=max_results)
 
 
 async def fetch_page(url: str) -> str:

--- a/mcp/tools/web.py
+++ b/mcp/tools/web.py
@@ -18,11 +18,11 @@ async def search_ddg(q: str, max_results: int = 5):
 
 async def search_tavily(q: str, max_results: int = 5):
     """Search using the Tavily API, returning results normalised to {title, href, body}."""
-    from tavily import TavilyClient
+    from tavily import AsyncTavilyClient
 
-    client = TavilyClient(api_key=os.environ["TAVILY_API_KEY"])
     try:
-        response = client.search(query=q, max_results=max_results)
+        client = AsyncTavilyClient(api_key=os.environ.get("TAVILY_API_KEY", ""))
+        response = await client.search(query=q, max_results=max_results)
     except Exception:
         return []
     results = []

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ typing-extensions>=4.12.2
 
 # Discovery
 duckduckgo-search>=6.2.10
+tavily-python>=0.3.0
 httpx>=0.27.0
 trafilatura>=1.10.0
 beautifulsoup4>=4.12.3


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable search backend for the MCP server's `/search` and `/research` endpoints, keeping DuckDuckGo as the default provider.

### What changed
- **`mcp/tools/web.py`**: Added `search_tavily()` function using the Tavily Python SDK, with result normalization to `{title, href, body}` format. Added `search_web()` dispatcher that routes to Tavily or DuckDuckGo based on the `SEARCH_PROVIDER` environment variable.
- **`mcp/server.py`**: Replaced direct `webtools.search_ddg()` calls in `/search` and `/research` endpoints with `webtools.search_web()` dispatcher.
- **`requirements.txt`**: Added `tavily-python>=0.3.0` dependency.
- **`.env.example`**: Documented `SEARCH_PROVIDER` and `TAVILY_API_KEY` environment variables.

### Dependency changes
- Added `tavily-python>=0.3.0` to `requirements.txt`

### Environment variable changes
- `SEARCH_PROVIDER` (optional, defaults to `duckduckgo`, set to `tavily` to use Tavily)
- `TAVILY_API_KEY` (required when `SEARCH_PROVIDER=tavily`)

### Notes for reviewers
- This is an **additive** change — DuckDuckGo remains the default and is fully preserved.
- The existing `search_ddg` function is unchanged, so existing tests that mock it directly continue to work.
- Result shape is normalized to `{title, href, body}` for Tavily results, matching the DuckDuckGo output format.


### Automated Review

- Passed after 2 attempt(s)
- Final review: This is attempt 2 addressing two prior review issues. Both fixes are correctly implemented: (1) `AsyncTavilyClient` is now used with `await client.search()`, eliminating the blocking-call-in-async-function problem; (2) client instantiation moved inside the `try/except` block and `os.environ.get("TAVILY_API_KEY", "")` used for graceful degradation when the key is absent. All relevant files are updated (`mcp/tools/web.py`, `mcp/server.py`, `requirements.txt`, `.env.example`). Existing tests remain valid — the DDGS mock path still works because `SEARCH_PROVIDER` defaults to `duckduckgo`. No regressions detected. One minor doc staleness issue found.
