### PR TITLE
feat: add Tavily search provider option to Agentic-RAG-Pipeline

### DIFF
--- a/Agentic-RAG-Pipeline/.env.example
+++ b/Agentic-RAG-Pipeline/.env.example
@@ -5,5 +5,11 @@ GOOGLE_API_KEY=YOUR_GEMINI_API_KEY
 CSE_API_KEY=YOUR_GOOGLE_CSE_API_KEY
 CSE_ENGINE_ID=YOUR_GOOGLE_CSE_ENGINE_ID
 
+# Optional: choose search provider — "google_cse" (default) or "tavily"
+# SEARCH_PROVIDER=google_cse
+
+# Optional (enable web retrieval via Tavily Search)
+# TAVILY_API_KEY=YOUR_TAVILY_API_KEY
+
 # Optional (local corpus directory)
 CORPUS_DIR=corpus

--- a/Agentic-RAG-Pipeline/app.py
+++ b/Agentic-RAG-Pipeline/app.py
@@ -4,7 +4,7 @@ from dotenv import load_dotenv
 
 from core.vector import FAISSIndex, ingest_corpus
 from core.memory import SessionMemory
-from core.tools import WebSearch
+from core.tools import WebSearch, TavilyWebSearch
 from graph.orchestrator import Orchestrator
 
 def ensure_env(var):
@@ -32,12 +32,18 @@ def main():
         print("[ingest] No corpus/ directory found. Running with empty vector store.")
 
     # --- Web search (optional) ---
+    search_provider = os.getenv("SEARCH_PROVIDER", "google_cse").lower()
+    tavily_key = os.getenv("TAVILY_API_KEY")
+
     web = None
-    if cse_key and cse_engine:
+    if search_provider == "tavily" and tavily_key:
+        web = TavilyWebSearch(api_key=tavily_key)
+        print("[web] Tavily Search enabled.")
+    elif cse_key and cse_engine:
         web = WebSearch(api_key=cse_key, engine_id=cse_engine)
         print("[web] Google Programmable Search enabled.")
     else:
-        print("[web] Web search disabled (set CSE_API_KEY & CSE_ENGINE_ID to enable).")
+        print("[web] Web search disabled (set CSE_API_KEY & CSE_ENGINE_ID, or TAVILY_API_KEY to enable).")
 
     # --- Memory ---
     memory = SessionMemory()  # in-process JSONL-style memory

--- a/Agentic-RAG-Pipeline/core/tools.py
+++ b/Agentic-RAG-Pipeline/core/tools.py
@@ -4,6 +4,7 @@ from typing import List, Dict, Optional
 import httpx
 import requests
 from bs4 import BeautifulSoup
+from tavily import TavilyClient
 
 class WebSearch:
     """
@@ -28,6 +29,25 @@ class WebSearch:
                     "snippet": it.get("snippet", "")
                 })
             return out
+
+class TavilyWebSearch:
+    """
+    Tavily Search API wrapper, matching the WebSearch interface.
+    """
+    def __init__(self, api_key: str):
+        self.client = TavilyClient(api_key=api_key)
+
+    def search(self, q: str, num: int = 5) -> List[Dict]:
+        response = self.client.search(query=q, max_results=num)
+        out = []
+        for it in response.get("results", []):
+            out.append({
+                "title": it.get("title"),
+                "url": it.get("url"),
+                "snippet": it.get("content", "")
+            })
+        return out
+
 
 def fetch_page_text(url: str, timeout: int = 20) -> Optional[str]:
     """

--- a/Agentic-RAG-Pipeline/requirements.txt
+++ b/Agentic-RAG-Pipeline/requirements.txt
@@ -6,3 +6,4 @@ beautifulsoup4>=4.12.2,<5.0.0
 pydantic>=2.7.0,<3.0.0
 python-dotenv>=1.0.1,<2.0.0
 numpy>=1.26.4,<3.0.0
+tavily-python>=0.3.0


### PR DESCRIPTION
## Summary

Adds Tavily as a configurable web search provider alongside the existing Google Custom Search Engine (CSE) in the Agentic-RAG-Pipeline sub-app. This is an **additive** change — Google CSE remains the default and is fully intact.

### What changed

- **`Agentic-RAG-Pipeline/core/tools.py`**: Added `TavilyWebSearch` class using `tavily-python` SDK, exposing the same `search(q, num)` interface and `{title, url, snippet}` return format as the existing `WebSearch` class.
- **`Agentic-RAG-Pipeline/app.py`**: Extended provider selection logic to check `SEARCH_PROVIDER` env var. When set to `"tavily"` and `TAVILY_API_KEY` is present, uses `TavilyWebSearch`; otherwise falls through to Google CSE as before.
- **`Agentic-RAG-Pipeline/.env.example`**: Added `SEARCH_PROVIDER` and `TAVILY_API_KEY` entries alongside existing CSE vars.
- **`Agentic-RAG-Pipeline/requirements.txt`**: Added `tavily-python>=0.3.0`.

### How to use

Set these environment variables to switch to Tavily:
```
SEARCH_PROVIDER=tavily
TAVILY_API_KEY=tvly-your-key
```

To keep using Google CSE (the default), no changes are needed.

### Notes for reviewers
- Google CSE code paths, env vars (`CSE_API_KEY`, `CSE_ENGINE_ID`), and dependencies are untouched.
- `TavilyWebSearch` maps Tavily's `content` field to `snippet` for interface compatibility.


### Automated Review

- Passed after 1 attempt(s)
- Final review: The migration is correct and complete. `TavilyWebSearch` properly mirrors the `WebSearch` interface, uses the right Tavily SDK call (`TavilyClient.search(query=..., max_results=...)`) with correct response field mapping (`content` → `snippet`), and the synchronous client is appropriate for this non-async app. `app.py` correctly implements the `SEARCH_PROVIDER` env-var gate while preserving the Google CSE fallback path. All four planned files are updated. Two minor issues: the `tavily-python` pin lacks an upper bound (inconsistent with all other deps), and there is no warning log when `SEARCH_PROVIDER=tavily` is set but `TAVILY_API_KEY` is absent (silent fallthrough to CSE/disabled).
